### PR TITLE
feat: Add AtfxSession for in-process access

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,8 +11,9 @@ content, and optionally expose them over an ASAM ODS HTTP interface.
 2. [ATFX File Format](#atfx-file-format)
 3. [Embedded Library — AtfxStore](#embedded-library--atfxstore)
 4. [HTTP Server — AtfxServer](#http-server--atfxserver)
-5. [CLI — Command Line Interface](#cli--command-line-interface)
-6. [Querying with odsbox ConI](#querying-with-odsbox-coni)
+5. [In-Process Access — AtfxSession](#in-process-access--atfxsession)
+6. [CLI — Command Line Interface](#cli--command-line-interface)
+7. [Querying with odsbox ConI](#querying-with-odsbox-coni)
 7. [Supported Content Types](#supported-content-types)
 8. [API Reference](#api-reference)
 
@@ -219,6 +220,78 @@ resp = requests.post(
 )
 # HTTP 201 — session URL in Location header
 session_url = resp.headers["Location"]
+```
+
+---
+
+## In-Process Access — AtfxSession
+
+`AtfxSession` is a `requests.Session` subclass that routes `ConI` HTTP calls
+directly to an `AtfxStore` — **no socket, no TCP, no port allocation**.
+It is the fastest way to use the `odsbox` `ConI` API against a local ATFX
+file when you do not need a real network endpoint.
+
+### When to use AtfxSession
+
+| Approach | Network? | Threads? | Best for |
+|---|---|---|---|
+| `AtfxStore` (direct) | No | No | Python-only, lowest-level access |
+| `AtfxSession` + `ConI` | No | No | Re-use existing `ConI` code in-process |
+| `AtfxServer` + `ConI` | Yes (localhost) | Yes | Remote clients, multi-process, CLI |
+
+### Basic usage — pass the file to AtfxSession
+
+```python
+from odsbox.con_i import ConI
+from asamatfx import AtfxSession
+
+with AtfxSession(default_file="path/to/file.atfx") as session:
+    with ConI(
+        url=session.url,       # "http://asamatfx.local" — no real HTTP
+        auth=None,
+        custom_session=session,
+    ) as con:
+        model = con.model_read()
+        df = con.query_data({"AoEnvironment": {}})
+        print(df)
+```
+
+### Using the ATFX_FILE context variable
+
+Passing the file via `context_variables` mirrors the `AtfxServer` pattern,
+making it easy to switch between in-process and HTTP access:
+
+```python
+from odsbox.con_i import ConI
+from asamatfx import AtfxSession, CONTEXT_VAR_ATFX_FILE
+
+with AtfxSession() as session:
+    with ConI(
+        url=session.url,
+        auth=None,
+        custom_session=session,
+        context_variables={CONTEXT_VAR_ATFX_FILE: "path/to/file.atfx"},
+        load_model=False,
+    ) as con:
+        model = con.model_read()
+```
+
+### Switching between AtfxSession and AtfxServer
+
+Because the `url` + `custom_session` interface is identical to the HTTP server
+pattern, you can swap in `AtfxServer` with minimal code changes:
+
+```python
+# In-process (no network)
+with AtfxSession(default_file="file.atfx") as session:
+    url, custom_session = session.url, session
+
+# Over HTTP (real server)
+# with AtfxServer(default_file="file.atfx") as server:
+#     url, custom_session = server.url, None
+
+with ConI(url=url, auth=None, custom_session=custom_session) as con:
+    model = con.model_read()
 ```
 
 ---

--- a/src/asamatfx/__init__.py
+++ b/src/asamatfx/__init__.py
@@ -2,5 +2,6 @@
 
 from ._atfx_store import AtfxStore
 from ._server import CONTEXT_VAR_ATFX_FILE, AtfxServer
+from ._session import AtfxSession
 
-__all__ = ["AtfxServer", "AtfxStore", "CONTEXT_VAR_ATFX_FILE"]
+__all__ = ["AtfxServer", "AtfxSession", "AtfxStore", "CONTEXT_VAR_ATFX_FILE"]

--- a/src/asamatfx/_session.py
+++ b/src/asamatfx/_session.py
@@ -1,0 +1,294 @@
+"""In-process requests adapter that routes ConI calls directly to AtfxStore.
+
+Provides :class:`AtfxSession`, a ``requests.Session`` subclass that intercepts
+ASAM ODS HTTP calls and dispatches them in-process to an :class:`AtfxStore` —
+no socket, no TCP, no port allocation required.
+
+Usage::
+
+    from odsbox.con_i import ConI
+    from asamatfx import AtfxSession, CONTEXT_VAR_ATFX_FILE
+
+    # Pass the ATFX file as a default (no context variable needed in ConI)
+    with AtfxSession(default_file="path/to/file.atfx") as session:
+        with ConI(url=session.url, custom_session=session, load_model=False) as con:
+            model = con.model_read()
+            result = con.data_read(select_statement)
+
+    # Or pass the file via the ATFX_FILE context variable (mirrors AtfxServer)
+    with AtfxSession() as session:
+        with ConI(
+            url=session.url,
+            custom_session=session,
+            context_variables={CONTEXT_VAR_ATFX_FILE: "path/to/file.atfx"},
+            load_model=False,
+        ) as con:
+            model = con.model_read()
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+import uuid
+from urllib.parse import urlparse
+
+import odsbox.proto.ods_pb2 as ods
+import requests
+import requests.adapters
+from google.protobuf import json_format
+from google.protobuf.message import Message
+from requests import Response
+from requests.cookies import cookiejar_from_dict
+from requests.models import PreparedRequest
+from requests.structures import CaseInsensitiveDict
+
+from asamatfx._atfx_store import AtfxStore
+from asamatfx._server import CONTENT_TYPE_JSON, CONTENT_TYPE_PROTO, CONTEXT_VAR_ATFX_FILE
+
+_log = logging.getLogger(__name__)
+
+_SYNTHETIC_BASE_URL: str = "http://asamatfx.local"
+"""Synthetic URL prefix used as the mount point for the in-process adapter."""
+
+
+class AtfxAdapter(requests.adapters.BaseAdapter):
+    """In-process transport adapter that handles ASAM ODS requests via AtfxStore.
+
+    Mirrors the routing and serialization logic of :class:`~asamatfx._server._AtfxRequestHandler`
+    without any network involvement.  Sessions are stored in an internal dict
+    keyed by UUID, exactly as in :class:`~asamatfx._server._AtfxHttpServer`.
+
+    :param default_file: Path to an ATFX file used when the ``ATFX_FILE``
+        context variable is not supplied on session creation.  Mirrors the
+        ``default_file`` parameter of :class:`~asamatfx.AtfxServer`.
+    """
+
+    def __init__(self, default_file: str | None = None) -> None:
+        super().__init__()
+        self._default_file: str | None = default_file
+        self._sessions: dict[str, AtfxStore] = {}
+        self._lock: threading.Lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # BaseAdapter interface
+
+    def send(
+        self,
+        request: PreparedRequest,
+        stream: bool = False,  # noqa: FBT001, FBT002
+        timeout: float | tuple[float, float] | None = None,
+        verify: bool | str = True,  # noqa: FBT001, FBT002
+        cert: str | tuple[str, str] | None = None,
+        proxies: dict[str, str] | None = None,
+    ) -> Response:
+        """Dispatch a PreparedRequest to the matching in-process handler."""
+        path = urlparse(request.url).path.lstrip("/")
+        parts = path.split("/")
+
+        method = (request.method or "").upper()
+
+        if method == "POST" and parts == ["ods"]:
+            return self._handle_connect(request)
+        if method == "POST" and len(parts) == 3 and parts[0] == "ods":
+            session_id, action = parts[1], parts[2]
+            if action == "context-read":
+                return self._handle_context_read(request, session_id)
+            if action == "model-read":
+                return self._handle_model_read(request, session_id)
+            if action == "data-read":
+                return self._handle_data_read(request, session_id)
+        if method == "DELETE" and len(parts) == 2 and parts[0] == "ods":
+            return self._handle_logout(request, parts[1])
+
+        return self._error_response(request, 404, "Endpoint not found")
+
+    def close(self) -> None:
+        """Close all managed AtfxStore instances."""
+        with self._lock:
+            for store in self._sessions.values():
+                store.close()
+            self._sessions.clear()
+
+    # ------------------------------------------------------------------
+    # Endpoint handlers
+
+    def _handle_connect(self, request: PreparedRequest) -> Response:
+        body = self._request_body(request)
+        ctx = ods.ContextVariables()
+        try:
+            self._deserialize(ctx, body, self._content_type(request))
+        except Exception as exc:  # noqa: BLE001
+            return self._error_response(request, 400, str(exc))
+
+        atfx_var = ctx.variables.get(CONTEXT_VAR_ATFX_FILE)
+        if atfx_var is not None and atfx_var.string_array.values:
+            file_path = atfx_var.string_array.values[0]
+        elif self._default_file is not None:
+            file_path = self._default_file
+        else:
+            return self._error_response(
+                request, 400, f"Missing context variable '{CONTEXT_VAR_ATFX_FILE}'"
+            )
+
+        try:
+            store = AtfxStore(file_path)
+        except Exception as exc:  # noqa: BLE001
+            return self._error_response(request, 400, f"Failed to load ATFX file: {exc}")
+
+        session_id = str(uuid.uuid4())
+        with self._lock:
+            self._sessions[session_id] = store
+
+        session_url = f"{_SYNTHETIC_BASE_URL}/ods/{session_id}"
+        _log.info("Session created: %s (file: %s)", session_id, file_path)
+
+        r = self._build_response(request, 201, b"")
+        r.headers["Location"] = session_url
+        return r
+
+    def _handle_context_read(self, request: PreparedRequest, session_id: str) -> Response:
+        store = self._get_session(session_id)
+        if store is None:
+            return self._error_response(request, 404, f"Session '{session_id}' not found")
+        return self._message_response(request, store.context_read())
+
+    def _handle_model_read(self, request: PreparedRequest, session_id: str) -> Response:
+        store = self._get_session(session_id)
+        if store is None:
+            return self._error_response(request, 404, f"Session '{session_id}' not found")
+        return self._message_response(request, store.model())
+
+    def _handle_data_read(self, request: PreparedRequest, session_id: str) -> Response:
+        store = self._get_session(session_id)
+        if store is None:
+            return self._error_response(request, 404, f"Session '{session_id}' not found")
+
+        body = self._request_body(request)
+        stmt = ods.SelectStatement()
+        try:
+            self._deserialize(stmt, body, self._content_type(request))
+        except Exception as exc:  # noqa: BLE001
+            return self._error_response(request, 400, f"Failed to parse SelectStatement: {exc}")
+
+        try:
+            result = store.data_read(stmt)
+        except Exception as exc:  # noqa: BLE001
+            _log.debug("Query error in session %s: %s", session_id, exc)
+            return self._error_response(request, 500, f"Query error: {exc}")
+
+        return self._message_response(request, result)
+
+    def _handle_logout(self, request: PreparedRequest, session_id: str) -> Response:
+        with self._lock:
+            store = self._sessions.pop(session_id, None)
+        if store is not None:
+            store.close()
+            _log.info("Session closed: %s", session_id)
+        return self._build_response(request, 200, b"")
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _get_session(self, session_id: str) -> AtfxStore | None:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+    @staticmethod
+    def _request_body(request: PreparedRequest) -> bytes:
+        body = request.body
+        if body is None:
+            return b""
+        if isinstance(body, bytes):
+            return body
+        return body.encode("utf-8")
+
+    @staticmethod
+    def _content_type(request: PreparedRequest) -> str:
+        headers = request.headers or {}
+        return str(headers.get("Content-Type", CONTENT_TYPE_PROTO))
+
+    @staticmethod
+    def _accept(request: PreparedRequest) -> str:
+        headers = request.headers or {}
+        return str(headers.get("Accept", CONTENT_TYPE_PROTO))
+
+    @staticmethod
+    def _deserialize(msg: Message, body: bytes, content_type: str) -> None:
+        if not body:
+            return
+        if CONTENT_TYPE_JSON in content_type:
+            json_format.Parse(body.decode("utf-8"), msg)
+        else:
+            msg.ParseFromString(body)
+
+    @staticmethod
+    def _serialize(msg: Message, accept: str) -> tuple[bytes, str]:
+        if CONTENT_TYPE_JSON in accept:
+            return json_format.MessageToJson(msg).encode("utf-8"), CONTENT_TYPE_JSON
+        return msg.SerializeToString(), CONTENT_TYPE_PROTO
+
+    def _message_response(self, request: PreparedRequest, msg: Message) -> Response:
+        body, content_type = self._serialize(msg, self._accept(request))
+        r = self._build_response(request, 200, body)
+        r.headers["Content-Type"] = content_type
+        return r
+
+    def _error_response(self, request: PreparedRequest, status: int, reason: str) -> Response:
+        _log.debug("Error %d: %s", status, reason)
+        error_info = ods.ErrorInfo()
+        error_info.reason = reason
+        body = error_info.SerializeToString()
+        r = self._build_response(request, status, body)
+        r.headers["Content-Type"] = CONTENT_TYPE_PROTO
+        return r
+
+    @staticmethod
+    def _build_response(request: PreparedRequest, status: int, body: bytes) -> Response:
+        r = Response()
+        r.status_code = status
+        r.headers = CaseInsensitiveDict({"Content-Length": str(len(body))})
+        r.url = request.url or ""
+        r.request = request
+        r._content = body  # type: ignore[attr-defined]
+        r._content_consumed = True  # type: ignore[attr-defined]
+        r.reason = ""
+        r.cookies = cookiejar_from_dict({})
+        r.history = []
+        r.elapsed = datetime.timedelta(0)
+        r.encoding = "utf-8"
+        return r
+
+
+class AtfxSession(requests.Session):
+    """A ``requests.Session`` that routes ASAM ODS calls in-process via AtfxStore.
+
+    Replaces the HTTP transport with an in-process adapter so that
+    :class:`~odsbox.con_i.ConI` can be used without starting an
+    :class:`~asamatfx.AtfxServer`.  All serialization, content-type
+    negotiation, and session management are handled identically to the HTTP
+    server — only the network layer is removed.
+
+    :param default_file: Path to an ATFX file used when the ``ATFX_FILE``
+        context variable is not supplied to :class:`~odsbox.con_i.ConI`.
+
+    Usage::
+
+        from odsbox.con_i import ConI
+        from asamatfx import AtfxSession
+
+        with AtfxSession(default_file="path/to/file.atfx") as session:
+            with ConI(url=session.url, custom_session=session) as con:
+                model = con.model_read()
+    """
+
+    def __init__(self, default_file: str | None = None) -> None:
+        super().__init__()
+        self._adapter = AtfxAdapter(default_file)
+        self.mount(_SYNTHETIC_BASE_URL + "/", self._adapter)
+
+    @property
+    def url(self) -> str:
+        """Base URL to pass as the ``url`` argument to :class:`~odsbox.con_i.ConI`."""
+        return _SYNTHETIC_BASE_URL

--- a/tests/test_example_atfx_session.py
+++ b/tests/test_example_atfx_session.py
@@ -1,0 +1,171 @@
+"""Example tests for AtfxSession — readable as usage documentation.
+
+These tests demonstrate the typical patterns for using ``AtfxSession`` as a
+drop-in replacement for ``AtfxServer`` when no HTTP server is needed.  They are
+intentionally verbose so that each test reads as a standalone usage example.
+
+Quick reference::
+
+    from asamatfx import AtfxSession, CONTEXT_VAR_ATFX_FILE
+    from odsbox.con_i import ConI
+
+    # Pattern 1 — pass the file path directly to AtfxSession
+    with AtfxSession(default_file="path/to/file.atfx") as session:
+        with ConI(url=session.url, custom_session=session) as con:
+            model = con.model_read()
+
+    # Pattern 2 — pass the file path through ConI context variables (mirrors AtfxServer)
+    with AtfxSession() as session:
+        with ConI(
+            url=session.url,
+            custom_session=session,
+            context_variables={CONTEXT_VAR_ATFX_FILE: "path/to/file.atfx"},
+        ) as con:
+            model = con.model_read()
+"""
+
+from pathlib import Path
+
+import odsbox.proto.ods_pb2 as ods
+from odsbox.con_i import ConI
+
+from asamatfx import CONTEXT_VAR_ATFX_FILE, AtfxSession
+
+# ---------------------------------------------------------------------------
+# Fixture file: the same ATFX used throughout the docs examples
+# ---------------------------------------------------------------------------
+SIMPLE_ATFX = Path(__file__).resolve().parent.parent / "docs" / "spec" / "examples" / "Example_Simple.atfx"
+
+
+# ---------------------------------------------------------------------------
+# Example 1 — connect using default_file
+# ---------------------------------------------------------------------------
+
+
+def test_connect_with_default_file():
+    """AtfxSession(default_file=...) lets ConI connect without a context variable.
+
+    This is the simplest pattern: pass the ATFX path once to the session and
+    then create a ConI with no extra arguments.
+    """
+    with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+        with ConI(
+            url=session.url,     # "http://asamatfx.local" — no real HTTP
+            auth=None,           # no authentication needed
+            custom_session=session,
+            load_model=True,     # cache the model on connect
+        ) as con:
+            model = con.model()
+
+    # The parsed model should contain the expected application entities
+    assert len(model.entities) > 0
+    assert "Environment" in model.entities
+    assert "Measurement" in model.entities
+
+
+# ---------------------------------------------------------------------------
+# Example 2 — connect using the ATFX_FILE context variable
+# ---------------------------------------------------------------------------
+
+
+def test_connect_with_context_variable():
+    """Passing ATFX_FILE via ConI context_variables mirrors AtfxServer behaviour.
+
+    Use this pattern when you want the same code to work with both
+    ``AtfxSession`` (in-process) and ``AtfxServer`` (over HTTP).
+    """
+    with AtfxSession() as session:          # no default_file on the session
+        with ConI(
+            url=session.url,
+            auth=None,
+            custom_session=session,
+            context_variables={CONTEXT_VAR_ATFX_FILE: str(SIMPLE_ATFX)},
+            load_model=False,
+        ) as con:
+            model = con.model_read()
+
+    assert "Environment" in model.entities
+
+
+# ---------------------------------------------------------------------------
+# Example 3 — query data via ConI.data_read()
+# ---------------------------------------------------------------------------
+
+
+def test_query_data_via_coni():
+    """Use ConI.data_read() to execute a SelectStatement in-process.
+
+    The result is the same ``ods.DataMatrices`` you would get from a real
+    ASAM ODS HTTP server, so existing parsing code can be reused unchanged.
+    """
+    with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+        with ConI(
+            url=session.url,
+            auth=None,
+            custom_session=session,
+            load_model=False,
+        ) as con:
+            model = con.model_read()
+
+            # Select the Name attribute of the Environment entity
+            env_entity = model.entities["Environment"]
+            stmt = ods.SelectStatement()
+            stmt.columns.add(aid=env_entity.aid, attribute="Id")
+            stmt.columns.add(aid=env_entity.aid, attribute="Name")
+
+            result = con.data_read(stmt)
+
+    assert len(result.matrices) == 1
+    matrix = result.matrices[0]
+    assert matrix.name == "Environment"
+
+    name_col = next(c for c in matrix.columns if c.name == "Name")
+    assert name_col.string_array.values[0] == "MyEnvironment"
+
+
+# ---------------------------------------------------------------------------
+# Example 4 — use ConI.query_data() with JAQueL
+# ---------------------------------------------------------------------------
+
+
+def test_query_data_jaquel():
+    """Use the higher-level ConI.query_data() with a JAQueL dict query.
+
+    ``query_data`` converts the dict to a ``SelectStatement`` and returns
+    a pandas DataFrame.  The in-process session is transparent to the caller.
+    """
+    with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+        with ConI(
+            url=session.url,
+            auth=None,
+            custom_session=session,
+        ) as con:
+            df = con.query_data({"AoEnvironment": {}, "$attributes": {"name": 1, "id": 1}})
+
+    assert not df.empty
+    assert "Environment.Name" in df.columns
+    assert "MyEnvironment" in df["Environment.Name"].values
+
+# ---------------------------------------------------------------------------
+# Example 5 — context-manager cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_cleanup():
+    """Both AtfxSession and ConI release resources cleanly on exit.
+
+    No exceptions should be raised when the nested ``with`` blocks exit,
+    even when ``load_model=True`` triggers an extra round-trip on connect.
+    """
+    with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+        with ConI(
+            url=session.url,
+            auth=None,
+            custom_session=session,
+            load_model=True,
+        ):
+            pass  # work would go here
+
+    # After both context managers exit the adapter should have no open sessions
+    # (ConI sends DELETE on __exit__; AtfxSession.close() handles the rest)
+    assert len(session._adapter._sessions) == 0

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,394 @@
+"""Tests for AtfxSession — in-process requests adapter for ConI."""
+
+from pathlib import Path
+
+import odsbox.proto.ods_pb2 as ods
+import pytest
+import requests
+from google.protobuf import json_format
+from odsbox.con_i import ConI
+
+from asamatfx import CONTEXT_VAR_ATFX_FILE, AtfxSession
+from asamatfx._session import AtfxAdapter
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "docs" / "spec" / "examples"
+SIMPLE_ATFX = DATA_DIR / "Example_Simple.atfx"
+
+CONTENT_TYPE_PROTO = "application/x-asamods+protobuf"
+CONTENT_TYPE_JSON = "application/x-asamods+json"
+
+
+# ==========================================================================
+# Connect / session lifecycle
+# ==========================================================================
+
+
+class TestConnect:
+    """Session creation and teardown."""
+
+    def test_connect_default_file_returns_201(self):
+        """POST /ods with default_file set returns 201 and Location."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            ctx = ods.ContextVariables()
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 201
+        assert "Location" in resp.headers
+        assert "/ods/" in resp.headers["Location"]
+
+    def test_connect_context_variable_returns_201(self):
+        """POST /ods with ATFX_FILE context variable returns 201."""
+        with AtfxSession() as session:
+            ctx = ods.ContextVariables()
+            ctx.variables[CONTEXT_VAR_ATFX_FILE].string_array.values.append(str(SIMPLE_ATFX))
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 201
+
+    def test_connect_missing_atfx_file_variable_returns_400(self):
+        """POST /ods without any file info returns 400."""
+        with AtfxSession() as session:
+            ctx = ods.ContextVariables()
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 400
+
+    def test_connect_bad_file_path_returns_400(self):
+        """POST /ods with a nonexistent file path returns 400."""
+        with AtfxSession() as session:
+            ctx = ods.ContextVariables()
+            ctx.variables[CONTEXT_VAR_ATFX_FILE].string_array.values.append("/nonexistent/file.atfx")
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 400
+
+    def test_logout_removes_session(self):
+        """DELETE session removes it; subsequent model-read returns 404."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            ctx = ods.ContextVariables()
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+            session_url = resp.headers["Location"]
+
+            del_resp = session.delete(session_url)
+            assert del_resp.status_code == 200
+
+            model_resp = session.post(
+                f"{session_url}/model-read",
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+            assert model_resp.status_code == 404
+
+    def test_unknown_session_returns_404(self):
+        """POST to an unknown session ID returns 404 with ErrorInfo body."""
+        with AtfxSession() as session:
+            resp = session.post(
+                f"{session.url}/ods/no-such-session/model-read",
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 404
+        error = ods.ErrorInfo()
+        error.ParseFromString(resp.content)
+        assert "no-such-session" in error.reason
+
+    def test_close_cleans_up_stores(self):
+        """close() on the session removes all tracked AtfxStore instances."""
+        session = AtfxSession(default_file=str(SIMPLE_ATFX))
+        ctx = ods.ContextVariables()
+        session.post(
+            f"{session.url}/ods",
+            data=ctx.SerializeToString(),
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        assert len(session._adapter._sessions) == 1
+        session.close()
+        assert len(session._adapter._sessions) == 0
+
+
+# ==========================================================================
+# Protobuf transport
+# ==========================================================================
+
+
+class TestProtobuf:
+    """End-to-end tests using binary protobuf encoding."""
+
+    @pytest.fixture
+    def session_url(self):
+        """Yield (session, session_url) with an open ODS session."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            ctx = ods.ContextVariables()
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+            yield session, resp.headers["Location"]
+
+    def test_context_read(self, session_url):
+        """context-read returns ContextVariables with version info."""
+        session, url = session_url
+        resp = session.post(
+            f"{url}/context-read",
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        assert resp.status_code == 200
+        cv = ods.ContextVariables()
+        cv.ParseFromString(resp.content)
+        assert "ASAM-ODS-VERSION" in cv.variables
+
+    def test_model_read_returns_entities(self, session_url):
+        """model-read returns ods.Model with expected entities."""
+        session, url = session_url
+        resp = session.post(
+            f"{url}/model-read",
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == CONTENT_TYPE_PROTO
+        model = ods.Model()
+        model.ParseFromString(resp.content)
+        assert len(model.entities) > 0
+        assert "Environment" in model.entities
+
+    def test_data_read_returns_matrices(self, session_url):
+        """data-read returns DataMatrices for a valid SelectStatement."""
+        session, url = session_url
+
+        model_resp = session.post(
+            f"{url}/model-read",
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        model = ods.Model()
+        model.ParseFromString(model_resp.content)
+        env_aid = model.entities["Environment"].aid
+
+        stmt = ods.SelectStatement()
+        stmt.columns.add(aid=env_aid, attribute="Id")
+        stmt.columns.add(aid=env_aid, attribute="Name")
+
+        resp = session.post(
+            f"{url}/data-read",
+            data=stmt.SerializeToString(),
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        assert resp.status_code == 200
+        result = ods.DataMatrices()
+        result.ParseFromString(resp.content)
+        assert len(result.matrices) == 1
+        assert result.matrices[0].name == "Environment"
+
+
+# ==========================================================================
+# JSON transport
+# ==========================================================================
+
+
+class TestJson:
+    """Tests using application/x-asamods+json encoding."""
+
+    @pytest.fixture
+    def open_session(self):
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            ctx = ods.ContextVariables()
+            resp = session.post(
+                f"{session.url}/ods",
+                data=ctx.SerializeToString(),
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+            yield session, resp.headers["Location"]
+
+    def test_connect_json_body(self):
+        """POST /ods with JSON-encoded ContextVariables creates session."""
+        with AtfxSession() as session:
+            ctx = ods.ContextVariables()
+            ctx.variables[CONTEXT_VAR_ATFX_FILE].string_array.values.append(str(SIMPLE_ATFX))
+            resp = session.post(
+                f"{session.url}/ods",
+                data=json_format.MessageToJson(ctx).encode("utf-8"),
+                headers={"Content-Type": CONTENT_TYPE_JSON, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 201
+
+    def test_model_read_json_accept(self, open_session):
+        """model-read with Accept: json returns JSON-encoded Model."""
+        session, url = open_session
+        resp = session.post(
+            f"{url}/model-read",
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_JSON},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == CONTENT_TYPE_JSON
+        model = ods.Model()
+        json_format.Parse(resp.content.decode("utf-8"), model)
+        assert "Environment" in model.entities
+
+    def test_data_read_json_body_and_accept(self, open_session):
+        """data-read accepts JSON request body and returns JSON DataMatrices."""
+        session, url = open_session
+        model_resp = session.post(
+            f"{url}/model-read",
+            headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+        )
+        model = ods.Model()
+        model.ParseFromString(model_resp.content)
+        env_aid = model.entities["Environment"].aid
+
+        stmt = ods.SelectStatement()
+        stmt.columns.add(aid=env_aid, attribute="Name")
+
+        resp = session.post(
+            f"{url}/data-read",
+            data=json_format.MessageToJson(stmt).encode("utf-8"),
+            headers={"Content-Type": CONTENT_TYPE_JSON, "Accept": CONTENT_TYPE_JSON},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["Content-Type"] == CONTENT_TYPE_JSON
+        result = ods.DataMatrices()
+        json_format.Parse(resp.content.decode("utf-8"), result)
+        assert len(result.matrices) >= 1
+
+
+# ==========================================================================
+# ConI integration
+# ==========================================================================
+
+
+class TestConI:
+    """Test that odsbox ConI works end-to-end with AtfxSession."""
+
+    def test_coni_model_read_default_file(self):
+        """ConI.model_read() returns valid model via AtfxSession (default_file)."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            with ConI(
+                url=session.url,
+                auth=None,
+                custom_session=session,
+                load_model=False,
+            ) as con:
+                model = con.model_read()
+        assert len(model.entities) > 0
+        assert "Measurement" in model.entities
+
+    def test_coni_model_read_context_variable(self):
+        """ConI.model_read() returns valid model via ATFX_FILE context variable."""
+        with AtfxSession() as session:
+            with ConI(
+                url=session.url,
+                auth=None,
+                custom_session=session,
+                context_variables={CONTEXT_VAR_ATFX_FILE: str(SIMPLE_ATFX)},
+                load_model=False,
+            ) as con:
+                model = con.model_read()
+        assert "Environment" in model.entities
+
+    def test_coni_data_read(self):
+        """ConI.data_read() returns DataMatrices with expected values."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            with ConI(
+                url=session.url,
+                auth=None,
+                custom_session=session,
+                load_model=False,
+            ) as con:
+                model = con.model_read()
+                env = model.entities["Environment"]
+                stmt = ods.SelectStatement()
+                stmt.columns.add(aid=env.aid, attribute="Id")
+                stmt.columns.add(aid=env.aid, attribute="Name")
+                result = con.data_read(stmt)
+
+        assert len(result.matrices) == 1
+        name_col = next(c for c in result.matrices[0].columns if c.name == "Name")
+        assert name_col.string_array.values[0] == "MyEnvironment"
+
+    def test_coni_bad_file_raises_http_error(self):
+        """ConI raises HTTPError when ATFX file cannot be loaded."""
+        with AtfxSession() as session:
+            with pytest.raises(requests.HTTPError):
+                ConI(
+                    url=session.url,
+                    auth=None,
+                    custom_session=session,
+                    context_variables={CONTEXT_VAR_ATFX_FILE: "/nonexistent/file.atfx"},
+                    load_model=False,
+                )
+
+    def test_multiple_concurrent_sessions(self):
+        """Two ConI instances on one AtfxSession work independently."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            with ConI(
+                url=session.url,
+                auth=None,
+                custom_session=session,
+                load_model=False,
+            ) as con1:
+                with ConI(
+                    url=session.url,
+                    auth=None,
+                    custom_session=session,
+                    load_model=False,
+                ) as con2:
+                    # Both sessions co-exist
+                    assert len(session._adapter._sessions) == 2
+                    model1 = con1.model_read()
+                    model2 = con2.model_read()
+
+        assert set(model1.entities.keys()) == set(model2.entities.keys())
+
+    def test_context_manager_cleanup(self):
+        """No errors raised when ConI and AtfxSession exit cleanly."""
+        with AtfxSession(default_file=str(SIMPLE_ATFX)) as session:
+            with ConI(
+                url=session.url,
+                auth=None,
+                custom_session=session,
+                load_model=True,
+            ):
+                pass  # simply verify no exception on entry/exit
+
+
+# ==========================================================================
+# AtfxAdapter direct tests
+# ==========================================================================
+
+
+class TestAtfxAdapter:
+    """Unit tests for AtfxAdapter in isolation."""
+
+    def test_adapter_url_property(self):
+        """AtfxSession.url returns the synthetic base URL."""
+        session = AtfxSession()
+        assert session.url == "http://asamatfx.local"
+        session.close()
+
+    def test_adapter_is_instance_of_base_adapter(self):
+        """AtfxAdapter inherits from requests BaseAdapter."""
+        adapter = AtfxAdapter()
+        assert isinstance(adapter, requests.adapters.BaseAdapter)
+        adapter.close()
+
+    def test_unknown_endpoint_returns_404(self):
+        """Requests to unknown paths get a 404 error response."""
+        with AtfxSession() as session:
+            resp = session.post(
+                f"{session.url}/ods/abc/unknown-action",
+                headers={"Content-Type": CONTENT_TYPE_PROTO, "Accept": CONTENT_TYPE_PROTO},
+            )
+        assert resp.status_code == 404


### PR DESCRIPTION
Introduce AtfxSession, a subclass of requests.Session, enabling direct routing of ConI HTTP calls to AtfxStore without network overhead. This addition enhances performance for local ATFX file access and includes usage examples and tests.