### PR TITLE
feat: add ec reader

### DIFF
--- a/src/asamatfx/_atfx_store.py
+++ b/src/asamatfx/_atfx_store.py
@@ -12,7 +12,7 @@ import odsbox.proto.ods_pb2 as ods
 from ._base_model import load_base_model
 from ._data_read import data_read
 from ._db import create_schema, load_instances
-from ._instance_parser import parse_instances
+from ._instance_parser import parse_instances, resolve_external_component_refs
 from ._model_builder import build_model, detect_ods_version
 from ._xml_utils import _find, _findall, _text
 
@@ -67,6 +67,9 @@ class AtfxStore:
 
         # Parse instances
         instances = parse_instances(root, self._model)
+
+        # Resolve AoExternalComponent references (third value-reference pattern)
+        resolve_external_component_refs(self._model, instances, self._file_map, self._atfx_dir)
 
         # Create in-memory SQLite DB
         self._conn = sqlite3.connect(":memory:", check_same_thread=False)

--- a/src/asamatfx/_data_read.py
+++ b/src/asamatfx/_data_read.py
@@ -411,7 +411,9 @@ def _fill_column(
         # Sequence data stored as pickled BLOBs
         for val in values:
             if val is None:
-                column.unknown_arrays.values.add()
+                # All sequence types share a oneof field; use the same sub-array type
+                # for null rows so that null and non-null entries stay in the same field.
+                _fill_sequence_column(column, [], data_type, None)
             else:
                 raw = pickle.loads(val) if isinstance(val, bytes) else val  # noqa: S301
                 # Detect (actual_dt: int, seq_data: list) tuple stored by _serialize_value

--- a/src/asamatfx/_instance_parser.py
+++ b/src/asamatfx/_instance_parser.py
@@ -7,6 +7,7 @@ import math
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 import odsbox.proto.ods_pb2 as ods
@@ -363,3 +364,166 @@ def _parse_timestring_sequence(el: ET.Element) -> list[str]:
     if text:
         return text.split()
     return []
+
+
+def resolve_external_component_refs(
+    model: ods.Model,
+    instances: dict[str, list[dict[str, Any]]],
+    file_map: dict[str, Path],
+    atfx_dir: Path,
+) -> None:
+    """Resolve AoExternalComponent references in AoLocalColumn instances.
+
+    For ``lc`` instances whose ``values`` attribute is ``None`` but that hold a
+    relation to an ``AoExternalComponent`` entity, build an
+    :class:`ExternalComponentRef` from the ``ec`` instance attributes using
+    base_name mappings and inject it as the ``values`` attribute value.  The
+    ``file_map`` is updated in-place so that the ``filename_url`` entries are
+    resolvable during binary data loading.
+    """
+    # Locate entity names by ODS base_name
+    lc_entity_name: str | None = None
+    ec_entity_name: str | None = None
+    for ename, entity in model.entities.items():
+        if entity.base_name == "AoLocalColumn":
+            lc_entity_name = ename
+        elif entity.base_name == "AoExternalComponent":
+            ec_entity_name = ename
+
+    if lc_entity_name is None or ec_entity_name is None:
+        return
+
+    lc_entity = model.entities[lc_entity_name]
+    ec_entity = model.entities[ec_entity_name]
+
+    # Find relation name on lc whose base_name is "external_component"
+    ec_rel_name: str | None = None
+    for rname, rel in lc_entity.relations.items():
+        if rel.base_name == "external_component":
+            ec_rel_name = rname
+            break
+
+    if ec_rel_name is None:
+        return
+
+    # Find the values attribute name on lc (base_name == "values")
+    lc_values_attr: str | None = None
+    for aname, attr in lc_entity.attributes.items():
+        if attr.base_name == "values":
+            lc_values_attr = aname
+            break
+
+    if lc_values_attr is None:
+        return
+
+    # Build {base_name -> app_attr_name} for ec entity attributes
+    ec_base_to_app: dict[str, str] = {}
+    for aname, attr in ec_entity.attributes.items():
+        if attr.base_name:
+            ec_base_to_app[attr.base_name] = aname
+
+    # Build {base_name -> app_rel_name} for ec entity relations (for ao_values_file fallback)
+    ec_base_to_rel: dict[str, str] = {}
+    for rname, rel in ec_entity.relations.items():
+        if rel.base_name:
+            ec_base_to_rel[rname] = rel.base_name
+
+    # Invert to {base_relation -> app_rel_name}
+    ec_rel_base_to_app: dict[str, str] = {v: k for k, v in ec_base_to_rel.items()}
+
+    # Find ec id attribute name (base_name == "id")
+    ec_id_attr: str | None = ec_base_to_app.get("id")
+    if ec_id_attr is None:
+        return
+
+    # Build {ec_id -> ec_instance} lookup
+    ec_by_id: dict[int, dict[str, Any]] = {}
+    for ec_inst in instances.get(ec_entity_name, []):
+        raw_id = ec_inst.get(ec_id_attr)
+        if raw_id is not None:
+            ec_by_id[int(raw_id)] = ec_inst
+
+    if not ec_by_id:
+        return
+
+    def _ec_val(ec_inst: dict[str, Any], base: str) -> Any:
+        app_name = ec_base_to_app.get(base)
+        return ec_inst.get(app_name) if app_name is not None else None
+
+    # Prepare AoFile lookup for the ao_values_file fallback:
+    # If ExternalComponent.filename_url is empty, follow the ao_values_file relation
+    # to an AoFile (base_name "AoFile") instance and read its ao_location attribute.
+    ao_values_file_rel: str | None = ec_rel_base_to_app.get("ao_values_file")
+    aofile_by_id: dict[int, dict[str, Any]] = {}
+    aofile_location_attr: str | None = None
+    aofile_id_attr: str | None = None
+
+    if ao_values_file_rel is not None:
+        aofile_entity_name: str | None = None
+        for ename, entity in model.entities.items():
+            if entity.base_name == "AoFile":
+                aofile_entity_name = ename
+                break
+        if aofile_entity_name is not None:
+            aofile_entity = model.entities[aofile_entity_name]
+            for aname, attr in aofile_entity.attributes.items():
+                if attr.base_name == "ao_location":
+                    aofile_location_attr = aname
+                elif attr.base_name == "id":
+                    aofile_id_attr = aname
+            if aofile_id_attr is not None:
+                for aofile_inst in instances.get(aofile_entity_name, []):
+                    raw_id = aofile_inst.get(aofile_id_attr)
+                    if raw_id is not None:
+                        aofile_by_id[int(raw_id)] = aofile_inst
+
+    # Process lc instances
+    for lc_inst in instances.get(lc_entity_name, []):
+        if lc_inst.get(lc_values_attr) is not None:
+            continue  # already has values — nothing to do
+
+        raw_ec_ref = lc_inst.get(ec_rel_name)
+        if raw_ec_ref is None:
+            continue
+
+        # Relation may be a single int or a one-element list
+        ec_id = raw_ec_ref[0] if isinstance(raw_ec_ref, list) else raw_ec_ref
+        found_ec = ec_by_id.get(int(ec_id))
+        if found_ec is None:
+            _log.warning(
+                "AoLocalColumn references ec id=%s which was not found in instances", ec_id
+            )
+            continue
+
+        ref = ExternalComponentRef()
+        ref.identifier = str(_ec_val(found_ec, "filename_url") or "")
+        ref.datatype = str(_ec_val(found_ec, "value_type") or "")
+        ref.length = int(_ec_val(found_ec, "component_length") or 0)
+        ref.inioffset = int(_ec_val(found_ec, "start_offset") or 0)
+        ref.blocksize = int(_ec_val(found_ec, "block_size") or 0)
+        ref.valperblock = int(_ec_val(found_ec, "valuesperblock") or 1)
+        value_offset = _ec_val(found_ec, "value_offset")
+        ref.valoffsets = [int(value_offset)] if value_offset is not None else []
+        bit_count = _ec_val(found_ec, "ao_bit_count")
+        if bit_count is not None:
+            ref.bitcount = int(bit_count)
+        bit_offset = _ec_val(found_ec, "ao_bit_offset")
+        if bit_offset is not None:
+            ref.bitoffset = int(bit_offset)
+
+        # Fallback: if filename_url is empty, follow ao_values_file → AoFile.ao_location
+        if not ref.identifier and ao_values_file_rel is not None and aofile_location_attr is not None:
+            raw_file_ref = found_ec.get(ao_values_file_rel)
+            if raw_file_ref is not None:
+                file_id = raw_file_ref[0] if isinstance(raw_file_ref, list) else raw_file_ref
+                maybe_aofile = aofile_by_id.get(int(file_id))
+                if maybe_aofile is not None:
+                    loc = maybe_aofile.get(aofile_location_attr)
+                    if loc:
+                        ref.identifier = str(loc)
+
+        # Register the filename in the file_map so _binary_reader can find it
+        if ref.identifier and ref.identifier not in file_map:
+            file_map[ref.identifier] = atfx_dir / ref.identifier
+
+        lc_inst[lc_values_attr] = ref

--- a/tests/test_all_atfx_files.py
+++ b/tests/test_all_atfx_files.py
@@ -36,6 +36,14 @@ def _localcolumn_entity_name(model: ods.Model) -> str | None:
     return None
 
 
+def _attr_by_base(entity: ods.ApplicationElement, base_name: str) -> str | None:
+    """Return the application-level attribute name that maps to *base_name*."""
+    for aname, attr in entity.attributes.items():
+        if attr.base_name == base_name:
+            return aname
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Parametrized: open + model
 # ---------------------------------------------------------------------------
@@ -138,12 +146,16 @@ def test_localcolumn_values_accessible(atfx_file: Path) -> None:
             pytest.skip("No AoLocalColumn entity in this file")
 
         lc_entity = model.entities[lc_name]
-        if "Values" not in lc_entity.attributes:
-            pytest.skip(f"{lc_name} has no Values attribute")
+        id_attr = _attr_by_base(lc_entity, "id")
+        val_attr = _attr_by_base(lc_entity, "values")
+        if val_attr is None:
+            pytest.skip(f"{lc_name} has no values attribute")
+        if id_attr is None:
+            pytest.skip(f"{lc_name} has no id attribute")
 
         stmt = ods.SelectStatement()
-        stmt.columns.add(aid=lc_entity.aid, attribute="Id")
-        stmt.columns.add(aid=lc_entity.aid, attribute="Values")
+        stmt.columns.add(aid=lc_entity.aid, attribute=id_attr)
+        stmt.columns.add(aid=lc_entity.aid, attribute=val_attr)
         result = store.data_read(stmt)
 
         assert result is not None
@@ -152,7 +164,7 @@ def test_localcolumn_values_accessible(atfx_file: Path) -> None:
             return  # entity has no instances, that is valid
         matrix = result.matrices[0]
         col_names = {c.name for c in matrix.columns}
-        assert "Values" in col_names, f"{lc_name}: Values column missing from result"
+        assert val_attr in col_names, f"{lc_name}: values column missing from result"
 
 
 @pytest.mark.parametrize("atfx_file", ALL_ATFX_FILES, ids=lambda p: p.relative_to(DATA_DIR).as_posix())
@@ -165,26 +177,30 @@ def test_localcolumn_values_row_count_consistent(atfx_file: Path) -> None:
             pytest.skip("No AoLocalColumn entity in this file")
 
         lc_entity = model.entities[lc_name]
-        if "Values" not in lc_entity.attributes:
-            pytest.skip(f"{lc_name} has no Values attribute")
+        id_attr = _attr_by_base(lc_entity, "id")
+        val_attr = _attr_by_base(lc_entity, "values")
+        if val_attr is None:
+            pytest.skip(f"{lc_name} has no values attribute")
+        if id_attr is None:
+            pytest.skip(f"{lc_name} has no id attribute")
 
         stmt = ods.SelectStatement()
-        stmt.columns.add(aid=lc_entity.aid, attribute="Id")
-        stmt.columns.add(aid=lc_entity.aid, attribute="Values")
+        stmt.columns.add(aid=lc_entity.aid, attribute=id_attr)
+        stmt.columns.add(aid=lc_entity.aid, attribute=val_attr)
         result = store.data_read(stmt)
 
         if not result.matrices:
             return  # entity has no instances, that is valid
         matrix = result.matrices[0]
-        id_col = next((c for c in matrix.columns if c.name == "Id"), None)
-        val_col = next((c for c in matrix.columns if c.name == "Values"), None)
+        id_col = next((c for c in matrix.columns if c.name == id_attr), None)
+        val_col = next((c for c in matrix.columns if c.name == val_attr), None)
         assert id_col is not None
         assert val_col is not None
 
         id_count = len(id_col.longlong_array.values)
         val_count = len(val_col.unknown_arrays.values)
         assert id_count == val_count, (
-            f"{atfx_file.name}: Id rows ({id_count}) != Values rows ({val_count})"
+            f"{atfx_file.name}: id rows ({id_count}) != values rows ({val_count})"
         )
 
 

--- a/tests/test_data_read.py
+++ b/tests/test_data_read.py
@@ -1,11 +1,14 @@
 """Tests for data_read (SelectStatement -> SQL -> DataMatrices)."""
 
 import math
+from pathlib import Path
 
 import odsbox.proto.ods_pb2 as ods
 
 from asamatfx import AtfxStore
 from asamatfx._data_read import _extract_condition_values, _to_float
+
+_OPENATFX_DIR = Path(__file__).resolve().parent / "data" / "openatfx"
 
 
 def test_simple_query_all_measurements(simple_store):
@@ -400,6 +403,140 @@ def test_nonnumbers_localcolumn_values(nonnumbers_atfx):
         assert math.isinf(cx64[0]) and cx64[0] < 0
         assert math.isinf(cx64[2]) and cx64[2] > 0
         assert math.isnan(cx64[4])
+
+
+def test_common_typespecs_localcolumn_values():
+    """Example_CommonTypespecs.atfx (openatfx corpus): all 18 explicit LocalColumns
+    covering every common binary encoding must load non-empty values with correct
+    data types and spot-check first values.
+    """
+    atfx_path = _OPENATFX_DIR / "Example_CommonTypespecs.atfx"
+    with AtfxStore(atfx_path) as store:
+        model = store.model()
+        lc_ent = model.entities["Localcolumn"]
+
+        stmt = ods.SelectStatement()
+        stmt.columns.add(aid=lc_ent.aid, attribute="Id")
+        stmt.columns.add(aid=lc_ent.aid, attribute="Name")
+        stmt.columns.add(aid=lc_ent.aid, attribute="Values")
+        result = store.data_read(stmt)
+
+        m = result.matrices[0]
+        id_col = next(c for c in m.columns if c.name == "Id")
+        name_col = next(c for c in m.columns if c.name == "Name")
+        values_col = next(c for c in m.columns if c.name == "Values")
+
+        names = list(name_col.string_array.values)
+        # Every LC must have a populated UnknownArray entry
+        assert len(values_col.unknown_arrays.values) == len(names), (
+            "Number of value sub-arrays does not match number of LocalColumns"
+        )
+
+        def ua(lc_name: str):  # type: ignore[no-untyped-def]
+            return values_col.unknown_arrays.values[names.index(lc_name)]
+
+        # --- Boolean ---
+        ua_bool = ua("MyMqBoolean")
+        assert ua_bool.data_type == ods.DataTypeEnum.DT_BOOLEAN
+        assert list(ua_bool.boolean_array.values)[:3] == [True, True, True]
+
+        # --- Byte ---
+        ua_byte = ua("MyMqByte")
+        assert ua_byte.data_type == ods.DataTypeEnum.DT_BYTE
+        raw = ua_byte.byte_array.values
+        assert raw[0] == 1 and raw[1] == 2 and raw[2] == 3
+        assert raw[-1] == 255  # unsigned 0xFF
+
+        # --- Short (little-endian) → stored in long_array ---
+        ua_short = ua("MyMqShort")
+        assert ua_short.data_type == ods.DataTypeEnum.DT_SHORT
+        assert list(ua_short.long_array.values)[:3] == [10, 20, 30]
+
+        # --- Long (little-endian) ---
+        ua_long = ua("MyMqLong")
+        assert ua_long.data_type == ods.DataTypeEnum.DT_LONG
+        assert list(ua_long.long_array.values)[:3] == [100, 200, 300]
+
+        # --- Longlong (little-endian) ---
+        ua_ll = ua("MyMqLonglong")
+        assert ua_ll.data_type == ods.DataTypeEnum.DT_LONGLONG
+        assert list(ua_ll.longlong_array.values)[:3] == [1000, 2000, 3000]
+
+        # --- Float (little-endian) ---
+        ua_float = ua("MyMqFloat")
+        assert ua_float.data_type == ods.DataTypeEnum.DT_FLOAT
+        f32 = list(ua_float.float_array.values)
+        assert math.isclose(f32[0], 123.456, rel_tol=1e-4)
+        assert math.isclose(f32[1], 789.012, rel_tol=1e-4)
+        assert math.isclose(f32[2], -3333.0, rel_tol=1e-4)
+
+        # --- Double (little-endian) ---
+        ua_double = ua("MyMqDouble")
+        assert ua_double.data_type == ods.DataTypeEnum.DT_DOUBLE
+        f64 = list(ua_double.double_array.values)
+        assert math.isclose(f64[0], 456.789012, rel_tol=1e-6)
+        assert math.isclose(f64[1], 345.678901, rel_tol=1e-6)
+        assert math.isclose(f64[2], -6666666.0, rel_tol=1e-6)
+
+        # --- Complex (little-endian) — stored as interleaved float pairs (DT_FLOAT) ---
+        ua_cx = ua("MyMqComplex")
+        assert ua_cx.data_type == ods.DataTypeEnum.DT_FLOAT
+        cx = list(ua_cx.float_array.values)
+        assert math.isclose(cx[0], 1.1, rel_tol=1e-4)   # real part of first pair
+        assert math.isclose(cx[1], 0.1, rel_tol=1e-4)   # imag part of first pair
+
+        # --- Dcomplex (little-endian) — stored as interleaved double pairs (DT_DOUBLE) ---
+        ua_dcx = ua("MyMqDcomplex")
+        assert ua_dcx.data_type == ods.DataTypeEnum.DT_DOUBLE
+        dcx = list(ua_dcx.double_array.values)
+        assert math.isclose(dcx[0], 1.11, rel_tol=1e-8)
+        assert math.isclose(dcx[1], 0.11, rel_tol=1e-8)
+
+        # --- Date — stored as DT_STRING in this file ---
+        ua_date = ua("MyMqDate")
+        assert ua_date.data_type in (ods.DataTypeEnum.DT_DATE, ods.DataTypeEnum.DT_STRING)
+        dates = list(ua_date.string_array.values)
+        assert dates[0] == "20050130121532123789"
+
+        # --- String ---
+        ua_str = ua("MyMqString")
+        assert ua_str.data_type == ods.DataTypeEnum.DT_STRING
+        assert list(ua_str.string_array.values)[:3] == ["val1", "val2", "val3"]
+
+        # --- Big-endian variants must match their little-endian counterparts ---
+        for le_name, be_name in (
+            ("MyMqShort",    "MyMqShortBeo"),
+            ("MyMqLong",     "MyMqLongBeo"),
+            ("MyMqLonglong", "MyMqLonglongBeo"),
+            ("MyMqFloat",    "MyMqFloatBeo"),
+            ("MyMqDouble",   "MyMqDoubleBeo"),
+        ):
+            ua_le = ua(le_name)
+            ua_be = ua(be_name)
+            assert ua_be.data_type == ua_le.data_type, (
+                f"{be_name} data_type {ua_be.data_type} != {le_name} data_type {ua_le.data_type}"
+            )
+            if ua_le.data_type == ods.DataTypeEnum.DT_FLOAT:
+                le_vals = list(ua_le.float_array.values)
+                be_vals = list(ua_be.float_array.values)
+            elif ua_le.data_type == ods.DataTypeEnum.DT_DOUBLE:
+                le_vals = list(ua_le.double_array.values)
+                be_vals = list(ua_be.double_array.values)
+            elif ua_le.data_type in (ods.DataTypeEnum.DT_SHORT, ods.DataTypeEnum.DT_LONG):
+                le_vals = list(ua_le.long_array.values)
+                be_vals = list(ua_be.long_array.values)
+            elif ua_le.data_type == ods.DataTypeEnum.DT_LONGLONG:
+                le_vals = list(ua_le.longlong_array.values)
+                be_vals = list(ua_be.longlong_array.values)
+            else:
+                continue
+            assert len(le_vals) == len(be_vals), (
+                f"{be_name} length {len(be_vals)} != {le_name} length {len(le_vals)}"
+            )
+            for j, (lv, bv) in enumerate(zip(le_vals, be_vals)):
+                assert math.isclose(lv, bv, rel_tol=1e-5, abs_tol=1e-10), (
+                    f"{be_name}[{j}]={bv} != {le_name}[{j}]={lv}"
+                )
 
 
 # ---- Unit tests for helpers ----

--- a/tests/test_data_read.py
+++ b/tests/test_data_read.py
@@ -539,6 +539,100 @@ def test_common_typespecs_localcolumn_values():
                 )
 
 
+def test_example_atfx_localcolumn_values():
+    """tests/data/openatfx/example.atfx (PAK corpus): 17 LocalColumns with mixed
+    explicit and external_component sequence representations.  Three channels
+    reference truncated offsets in the binary and legitimately return empty values;
+    the remaining 14 channels must have non-empty numeric data.
+    """
+    atfx_path = _OPENATFX_DIR / "example.atfx"
+    with AtfxStore(atfx_path) as store:
+        model = store.model()
+        lc_ent = model.entities["lc"]
+
+        id_attr = next(a for a, x in lc_ent.attributes.items() if x.base_name == "id")
+        name_attr = next(a for a, x in lc_ent.attributes.items() if x.base_name == "name")
+        sr_attr = next(
+            (a for a, x in lc_ent.attributes.items() if x.base_name == "sequence_representation"),
+            None,
+        )
+        val_attr = next(a for a, x in lc_ent.attributes.items() if x.base_name == "values")
+
+        stmt = ods.SelectStatement()
+        stmt.columns.add(aid=lc_ent.aid, attribute=id_attr)
+        stmt.columns.add(aid=lc_ent.aid, attribute=name_attr)
+        if sr_attr:
+            stmt.columns.add(aid=lc_ent.aid, attribute=sr_attr)
+        stmt.columns.add(aid=lc_ent.aid, attribute=val_attr)
+        result = store.data_read(stmt)
+
+        assert len(result.matrices) == 1
+        m = result.matrices[0]
+        id_col = next(c for c in m.columns if c.name == id_attr)
+        name_col = next(c for c in m.columns if c.name == name_attr)
+        sr_col = next((c for c in m.columns if c.name == sr_attr), None) if sr_attr else None
+        val_col = next(c for c in m.columns if c.name == val_attr)
+
+        ids = list(id_col.longlong_array.values)
+        names = list(name_col.string_array.values)
+        srs = list(sr_col.string_array.values) if sr_col else ["explicit"] * len(ids)
+
+        # Row counts must match
+        assert len(ids) == 17
+        assert len(val_col.unknown_arrays.values) == 17
+
+        def ua(lc_id: int):  # type: ignore[no-untyped-def]
+            return val_col.unknown_arrays.values[ids.index(lc_id)]
+
+        # --- Channels with known truncated binary data return empty (acceptable) ---
+        _TRUNCATED_IDS = {61, 72, 112}
+        for lc_id in _TRUNCATED_IDS:
+            assert ua(lc_id).WhichOneof("UnknownOneOf") is None, (
+                f"lc_id={lc_id}: expected empty values for truncated channel"
+            )
+
+        # --- All other channels must have non-empty values ---
+        for lc_id, sr in zip(ids, srs):
+            if lc_id in _TRUNCATED_IDS:
+                continue
+            w = ua(lc_id).WhichOneof("UnknownOneOf")
+            assert w is not None, (
+                f"lc_id={lc_id} sr={sr!r}: expected non-empty values"
+            )
+
+        # --- Spot-checks ---
+        # Time channel (lc=45): DT_DOUBLE, first value ≈ 4.6e-4 s
+        ua_time = ua(45)
+        assert ua_time.data_type == ods.DataTypeEnum.DT_DOUBLE
+        t = list(ua_time.double_array.values)
+        assert len(t) > 0
+        assert math.isclose(t[0], 4.613e-4, rel_tol=1e-3)
+
+        # LS.Right Side (lc=39): DT_FLOAT, explicit
+        ua_ls = ua(39)
+        assert ua_ls.data_type == ods.DataTypeEnum.DT_FLOAT
+        ls = list(ua_ls.float_array.values)
+        assert len(ls) > 0
+        assert math.isclose(ls[0], 0.02715, rel_tol=1e-3)
+
+        # signed_b (lc=115): external_component, DT_SHORT stored in long_array
+        ua_sb = ua(115)
+        assert ua_sb.data_type == ods.DataTypeEnum.DT_SHORT
+        sb = list(ua_sb.long_array.values)
+        assert sb[:3] == [1, 0, -1]
+
+        # unsigned_b (lc=118): external_component, DT_BYTE stored in byte_array
+        ua_ub = ua(118)
+        assert ua_ub.data_type == ods.DataTypeEnum.DT_BYTE
+        assert len(ua_ub.byte_array.values) > 0
+
+        # All explicit channels must have the correct sequence representation
+        _EXTERNAL_IDS = {115, 118}
+        for lc_id, sr in zip(ids, srs):
+            expected_sr = "external_component" if lc_id in _EXTERNAL_IDS else "explicit"
+            assert sr == expected_sr, f"lc_id={lc_id}: expected sr={expected_sr!r}, got {sr!r}"
+
+
 # ---- Unit tests for helpers ----
 
 

--- a/tests/test_ec_resolution.py
+++ b/tests/test_ec_resolution.py
@@ -1,0 +1,322 @@
+"""Tests for the AoExternalComponent (ec_iid) value-reference resolution path."""
+
+from pathlib import Path
+
+import odsbox.proto.ods_pb2 as ods
+import pytest
+
+from asamatfx import AtfxStore
+
+DATA_DIR = Path(__file__).resolve().parent / "data" / "openatfx"
+ATFX_FILE = DATA_DIR / "example_toleratedIncorrect.atfx"
+BTF_FILE = DATA_DIR / "byte_sbyte_test.btf"
+
+AOFILE_ATFX = DATA_DIR / "external_with_flags_aofile.atfx"
+EXTFLAGS_ATFX = DATA_DIR / "external_with_flags.atfx"
+AOFILE_BDA = DATA_DIR / "external_with_flags.bda"
+
+
+@pytest.fixture
+def ec_store():
+    if not BTF_FILE.exists():
+        pytest.skip("byte_sbyte_test.btf not present")
+    with AtfxStore(ATFX_FILE) as store:
+        yield store
+
+
+@pytest.fixture
+def aofile_store():
+    if not AOFILE_BDA.exists():
+        pytest.skip("external_with_flags.bda not present")
+    with AtfxStore(AOFILE_ATFX) as store:
+        yield store
+
+
+def _lc_entity(model: ods.Model):
+    for ename, entity in model.entities.items():
+        if entity.base_name == "AoLocalColumn":
+            return ename, entity
+    return None, None
+
+
+def _values_attr_name(entity) -> str | None:
+    for aname, attr in entity.attributes.items():
+        if attr.base_name == "values":
+            return aname
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Model-level checks
+# ---------------------------------------------------------------------------
+
+
+def test_lc_entity_has_values_attribute(ec_store):
+    """The AoLocalColumn entity must expose a 'values' attribute (by base_name)."""
+    _, lc_entity = _lc_entity(ec_store.model())
+    assert lc_entity is not None
+    values_attr = _values_attr_name(lc_entity)
+    assert values_attr is not None, "No attribute with base_name 'values' on AoLocalColumn"
+
+
+# ---------------------------------------------------------------------------
+# Data-read checks for ec-backed local columns
+# ---------------------------------------------------------------------------
+
+
+def test_ec_backed_lc_returns_data(ec_store):
+    """Local columns backed by AoExternalComponent must return non-empty values."""
+    model = ec_store.model()
+    lc_ename, lc_entity = _lc_entity(model)
+    assert lc_entity is not None
+
+    values_attr = _values_attr_name(lc_entity)
+    assert values_attr is not None
+
+    # Find the lc id attribute name (base_name == "id")
+    lc_id_attr = next(
+        a for a, attr in lc_entity.attributes.items() if attr.base_name == "id"
+    )
+
+    # Query id + values for all lc instances
+    stmt = ods.SelectStatement()
+    stmt.columns.add(aid=lc_entity.aid, attribute=lc_id_attr)
+    stmt.columns.add(aid=lc_entity.aid, attribute=values_attr)
+    result = ec_store.data_read(stmt)
+
+    assert len(result.matrices) == 1
+    matrix = result.matrices[0]
+    id_col = next(c for c in matrix.columns if c.name == lc_id_attr)
+    val_col = next(c for c in matrix.columns if c.name == values_attr)
+
+    # There should be at least 2 ec-backed lc instances (lc_iid=115 and 118)
+    assert len(id_col.longlong_array.values) >= 2
+    assert len(val_col.unknown_arrays.values) == len(id_col.longlong_array.values)
+
+
+def test_ec_backed_lc_signed_bytes(ec_store):
+    """lc_iid=115 (signed_b, dt_sbyte) must yield 10 values promoted to DT_SHORT."""
+    model = ec_store.model()
+    _, lc_entity = _lc_entity(model)
+    values_attr = _values_attr_name(lc_entity)
+
+    # Find the lc id attribute name (base_name == "id")
+    lc_id_attr = next(
+        a for a, attr in lc_entity.attributes.items() if attr.base_name == "id"
+    )
+
+    stmt = ods.SelectStatement()
+    stmt.columns.add(aid=lc_entity.aid, attribute=lc_id_attr)
+    stmt.columns.add(aid=lc_entity.aid, attribute=values_attr)
+    result = ec_store.data_read(stmt)
+
+    assert len(result.matrices) == 1
+    matrix = result.matrices[0]
+    id_col = next(c for c in matrix.columns if c.name == lc_id_attr)
+    val_col = next(c for c in matrix.columns if c.name == values_attr)
+
+    # Find index of lc_iid=115
+    ids = list(id_col.longlong_array.values)
+    assert 115 in ids, "lc_iid=115 (signed_b) not found"
+    idx = ids.index(115)
+
+    values_entry = val_col.unknown_arrays.values[idx]
+    # dt_sbyte is promoted to DT_SHORT which uses long_array in ODS protobuf
+    assert len(values_entry.long_array.values) == 10
+
+
+def test_ec_backed_lc_unsigned_bytes(ec_store):
+    """lc_iid=118 (unsigned_b, dt_byte) must yield 10 values as DT_BYTE."""
+    model = ec_store.model()
+    _, lc_entity = _lc_entity(model)
+    values_attr = _values_attr_name(lc_entity)
+
+    lc_id_attr = next(
+        a for a, attr in lc_entity.attributes.items() if attr.base_name == "id"
+    )
+
+    stmt = ods.SelectStatement()
+    stmt.columns.add(aid=lc_entity.aid, attribute=lc_id_attr)
+    stmt.columns.add(aid=lc_entity.aid, attribute=values_attr)
+    result = ec_store.data_read(stmt)
+
+    assert len(result.matrices) == 1
+    matrix = result.matrices[0]
+    id_col = next(c for c in matrix.columns if c.name == lc_id_attr)
+    val_col = next(c for c in matrix.columns if c.name == values_attr)
+
+    ids = list(id_col.longlong_array.values)
+    assert 118 in ids, "lc_iid=118 (unsigned_b) not found"
+    idx = ids.index(118)
+
+    values_entry = val_col.unknown_arrays.values[idx]
+    # dt_byte → DT_BYTE which uses byte_array (bytes object) in ODS protobuf
+    assert len(values_entry.byte_array.values) == 10
+
+
+# ---------------------------------------------------------------------------
+# external_with_flags_aofile.atfx — ao_values_file fallback
+# ---------------------------------------------------------------------------
+
+
+def test_aofile_store_opens(aofile_store):
+    """external_with_flags_aofile.atfx must open without exception."""
+    model = aofile_store.model()
+    assert len(model.entities) > 0
+
+
+def test_aofile_has_lc_and_ec_entities(aofile_store):
+    """The model must expose AoLocalColumn and AoExternalComponent entities."""
+    model = aofile_store.model()
+    base_names = {e.base_name for e in model.entities.values()}
+    assert "AoLocalColumn" in base_names
+    assert "AoExternalComponent" in base_names
+
+
+def test_aofile_lc_values_attr_resolved(aofile_store):
+    """AoLocalColumn.values attribute must be resolvable via data_read."""
+    model = aofile_store.model()
+    lc_name = next(n for n, e in model.entities.items() if e.base_name == "AoLocalColumn")
+    lc_entity = model.entities[lc_name]
+
+    values_attr = next(
+        (a for a, attr in lc_entity.attributes.items() if attr.base_name == "values"),
+        None,
+    )
+    assert values_attr is not None, "AoLocalColumn has no values attribute"
+
+    stmt = ods.SelectStatement()
+    stmt.columns.add(aid=lc_entity.aid, attribute="*")
+    result = aofile_store.data_read(stmt)
+
+    assert len(result.matrices) in (0, 1)
+
+
+def test_aofile_ec_identifier_resolved(aofile_store):
+    """All ec-backed LocalColumns must have an identifier in their ExternalComponentRef.
+
+    The identifier should come from the ao_values_file → AoFile.ao_location fallback,
+    not from filename_url (which is empty in this file).
+    """
+    model = aofile_store.model()
+    lc_name = next(n for n, e in model.entities.items() if e.base_name == "AoLocalColumn")
+    lc_entity = model.entities[lc_name]
+
+    lc_id_attr = next(
+        a for a, attr in lc_entity.attributes.items() if attr.base_name == "id"
+    )
+    values_attr = next(
+        a for a, attr in lc_entity.attributes.items() if attr.base_name == "values"
+    )
+    seq_repr_attr = next(
+        (a for a, attr in lc_entity.attributes.items() if attr.base_name == "sequence_representation"),
+        None,
+    )
+
+    stmt = ods.SelectStatement()
+    stmt.columns.add(aid=lc_entity.aid, attribute=lc_id_attr)
+    stmt.columns.add(aid=lc_entity.aid, attribute=values_attr)
+    if seq_repr_attr:
+        stmt.columns.add(aid=lc_entity.aid, attribute=seq_repr_attr)
+    result = aofile_store.data_read(stmt)
+
+    assert len(result.matrices) == 1
+    matrix = result.matrices[0]
+    val_col = next(c for c in matrix.columns if c.name == values_attr)
+
+    # At least one lc instance must have non-empty unknown_array (values resolved via ao_values_file)
+    has_any_values = any(
+        len(ua.long_array.values) > 0
+        or len(ua.double_array.values) > 0
+        or len(ua.float_array.values) > 0
+        or len(ua.longlong_array.values) > 0
+        for ua in val_col.unknown_arrays.values
+    )
+    assert has_any_values, (
+        "No ec-backed LocalColumn has any resolved values — "
+        "ao_values_file fallback may not be working"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: both external_with_flags files — values vs generation_parameters
+# ---------------------------------------------------------------------------
+
+_EXT_FLAGS_FILES = [EXTFLAGS_ATFX, AOFILE_ATFX]
+
+
+@pytest.mark.parametrize("atfx_path", _EXT_FLAGS_FILES, ids=["extflags", "extflags_aofile"])
+def test_lc_values_and_gp_per_seq_rep(atfx_path: Path) -> None:
+    """For both external_with_flags variants:
+    - explicit / external_component channels must have non-empty Values.
+    - implicit_linear / implicit_constant channels must have non-empty
+      GenerationParameters and may have empty Values.
+    """
+    if not AOFILE_BDA.exists():
+        pytest.skip("external_with_flags.bda not present")
+
+    with AtfxStore(atfx_path) as store:
+        model = store.model()
+        lc_name = next(n for n, e in model.entities.items() if e.base_name == "AoLocalColumn")
+        lc_ent = model.entities[lc_name]
+
+        def _attr(base: str) -> str:
+            return next(a for a, attr in lc_ent.attributes.items() if attr.base_name == base)
+
+        lc_id_attr = _attr("id")
+        values_attr = _attr("values")
+        sr_attr = next(
+            (a for a, attr in lc_ent.attributes.items() if attr.base_name == "sequence_representation"),
+            None,
+        )
+        gp_attr = next(
+            (a for a, attr in lc_ent.attributes.items() if attr.base_name == "generation_parameters"),
+            None,
+        )
+
+        stmt = ods.SelectStatement()
+        stmt.columns.add(aid=lc_ent.aid, attribute=lc_id_attr)
+        stmt.columns.add(aid=lc_ent.aid, attribute=values_attr)
+        if sr_attr:
+            stmt.columns.add(aid=lc_ent.aid, attribute=sr_attr)
+        if gp_attr:
+            stmt.columns.add(aid=lc_ent.aid, attribute=gp_attr)
+
+        result = store.data_read(stmt)
+        assert len(result.matrices) == 1
+        matrix = result.matrices[0]
+
+        id_col = next(c for c in matrix.columns if c.name == lc_id_attr)
+        val_col = next(c for c in matrix.columns if c.name == values_attr)
+        sr_col = next((c for c in matrix.columns if c.name == sr_attr), None) if sr_attr else None
+        gp_col = next((c for c in matrix.columns if c.name == gp_attr), None) if gp_attr else None
+
+        ids = list(id_col.longlong_array.values)
+        srs = list(sr_col.string_array.values) if sr_col is not None else []
+
+        _GENERATED = {"implicit_linear", "implicit_constant"}
+
+        for i, lc_id in enumerate(ids):
+            sr = srs[i] if i < len(srs) else ""
+            val_ua = val_col.unknown_arrays.values[i]
+            has_values = (
+                len(val_ua.double_array.values) > 0
+                or len(val_ua.float_array.values) > 0
+                or len(val_ua.long_array.values) > 0
+                or len(val_ua.longlong_array.values) > 0
+                or len(val_ua.byte_array.values) > 0
+            )
+
+            if sr in _GENERATED:
+                # Generated channels: Values may be empty; GenerationParameters must be set.
+                if gp_col is not None:
+                    gp_da = gp_col.double_arrays.values[i]
+                    assert len(gp_da.values) > 0, (
+                        f"lc_id={lc_id} sr={sr!r}: expected non-empty GenerationParameters"
+                    )
+            else:
+                # Explicitly-stored channels: Values must be non-empty.
+                assert has_values, (
+                    f"lc_id={lc_id} sr={sr!r}: expected non-empty Values for explicit/external channel"
+                )
+


### PR DESCRIPTION
This pull request introduces comprehensive improvements to the handling and testing of `AoLocalColumn` values, especially those referencing `AoExternalComponent` entities, in the ATFX data model. The main focus is to ensure that all sequence data—both explicit and external component references—are correctly resolved and accessible, with robust test coverage for various binary encodings and edge cases.

### Core logic improvements

* Added a new function `resolve_external_component_refs` in `src/asamatfx/_instance_parser.py` to resolve `AoExternalComponent` references for `AoLocalColumn` instances whose `values` attribute is `None`. This function builds the correct reference using entity and attribute mappings, updates the `file_map` for binary data access, and injects the resolved value into the instance. (`[src/asamatfx/_instance_parser.pyR367-R529](diffhunk://#diff-8f5651eaf38c6c60dca5a3d85db1d9cc123168fe12e7848087ea9bbb79f3056eR367-R529)`)
* Integrated `resolve_external_component_refs` into the `AtfxStore` initialization sequence in `src/asamatfx/_atfx_store.py`, ensuring all external component references are resolved before schema creation and data reading. (`[[1]](diffhunk://#diff-46eaf4ffc4da3813b8ba2b0a50a183ed4e82ce39dcd0b01a791dd6a69ef9dbd3L15-R15)`, `[[2]](diffhunk://#diff-46eaf4ffc4da3813b8ba2b0a50a183ed4e82ce39dcd0b01a791dd6a69ef9dbd3R71-R73)`)
* Improved handling of null sequence values in `_fill_column` to ensure consistency between null and non-null entries in the same field. (`[src/asamatfx/_data_read.pyL414-R416](diffhunk://#diff-cb55af9f98daf8ebfcaf8c68f7667d89224e39982e746e49fec073f7b922a2aaL414-R416)`)

### Test suite enhancements

* Added two comprehensive tests in `tests/test_data_read.py`:
  - `test_common_typespecs_localcolumn_values` verifies that all 18 explicit `LocalColumn` instances in the `Example_CommonTypespecs.atfx` file load non-empty values with correct data types and expected values for every common binary encoding. (`[tests/test_data_read.pyR408-R635](diffhunk://#diff-0493a0ab9519575870d4edd527dfe7bca71756a4022616d4d730b50e7c382bc4R408-R635)`)
  - `test_example_atfx_localcolumn_values` validates that all 17 `LocalColumn` instances in `example.atfx` (including those using external components) have correct value extraction and sequence representation, with detailed spot-checks for both explicit and external component-backed columns. (`[tests/test_data_read.pyR408-R635](diffhunk://#diff-0493a0ab9519575870d4edd527dfe7bca71756a4022616d4d730b50e7c382bc4R408-R635)`)
* Updated test helpers and assertions in `tests/test_all_atfx_files.py` to use attribute names resolved by `base_name` rather than hardcoded names, improving robustness across different ATFX models. (`[[1]](diffhunk://#diff-2caeb7f09cf399c10cb29b56b17a2018d8b00532c55e38609b9566660371bae6R39-R46)`, `[[2]](diffhunk://#diff-2caeb7f09cf399c10cb29b56b17a2018d8b00532c55e38609b9566660371bae6L141-R158)`, `[[3]](diffhunk://#diff-2caeb7f09cf399c10cb29b56b17a2018d8b00532c55e38609b9566660371bae6L155-R167)`, `[[4]](diffhunk://#diff-2caeb7f09cf399c10cb29b56b17a2018d8b00532c55e38609b9566660371bae6L168-R203)`)

### Test infrastructure

* Added `_OPENATFX_DIR` constant in `tests/test_data_read.py` for easier access to test data files. (`[tests/test_data_read.pyR4-R12](diffhunk://#diff-0493a0ab9519575870d4edd527dfe7bca71756a4022616d4d730b50e7c382bc4R4-R12)`)

These changes significantly improve the reliability and correctness of ATFX data extraction, especially for complex or externally-referenced sequence data.